### PR TITLE
Allow the NewProjectile wrapper to target the correct override.

### DIFF
--- a/Prism.Injector/Patcher/ProjectilePatcher.cs
+++ b/Prism.Injector/Patcher/ProjectilePatcher.cs
@@ -17,7 +17,7 @@ namespace Prism.Injector.Patcher
         {
             typeDef_Proj.GetMethod("SetDefaults", MethodFlags.Public | MethodFlags.Instance, new[] { typeSys.Int32 }).Wrap(context);
 
-            typeDef_Proj.GetMethod("NewProjectile").Wrap(context, "Terraria.PrismInjections", "Projectile_NewProjectileDel", "P_OnNewProjectile");
+            typeDef_Proj.GetMethods("NewProjectile").First(method => method.Parameters[0].Type == typeSys.Single).Wrap(context, "Terraria.PrismInjections", "Projectile_NewProjectileDel", "P_OnNewProjectile");
 
             typeDef_Proj.GetMethod("AI"       , MethodFlags.Public | MethodFlags.Instance               ).Wrap(context);
             typeDef_Proj.GetMethod("Update"   , MethodFlags.Public | MethodFlags.Instance, new[] { typeSys.Int32 }).Wrap(context);


### PR DESCRIPTION
On Linux, the float-based override is listed first; on Windows, it's the other way around. This allows for correct targeting regardless of system (if there ever is added a separate override that also starts with a single-precision floating point argument, this will need fixing again).